### PR TITLE
add ruptures

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following list is by no means exhaustive, feel free to edit the list (will p
 | [pysf](https://github.com/alan-turing-institute/pysf) | A scikit-learn compatible machine learning library for supervised/panel forecasting |
 | [pyramid](https://github.com/tgsmith61591/pyramid) | port of R's auto.arima method to Python |
 | [pyts](https://github.com/johannfaouzi/pyts) | Contains time series preprocessing, transformation as well as classification techniques |
+| [ruptures](https://github.com/deepcharles/ruptures) | Provides methods to find change points in time series such as shifts in the mean or scale of the signal as well as more complex changes in the probability distribution or frequency. |
 | [seglearn](https://github.com/dmbee/seglearn) | Extends the scikit-learn pipeline concept to sequence data |
 | [sktime](https://github.com/alan-turing-institute/sktime) | A scikit-learn compatible library for learning with time series/panel data including time series classification/regression and (supervised/panel) forecasting |
 | [statsmodels](https://github.com/statsmodels/statsmodels) | Contains a submodule for classical time series models and hypothesis tests |


### PR DESCRIPTION
Hello,

We actively maintain a package (`ruptures`) that does change point detection on time series. It consists in finding the instants where a signal changes its behaviour; it can be a shift in the mean, scale or more complex changes in the probability distribution, frequency, etc.
That would be great if you could add it to your list.

Also, thanks for this list. Usually, users of `ruptures` segment their signals and then classify each segment (to do activity recognition for instance), and several listed packages could be used for this purpose. I will certainly try one or two and add an illustrative example in the docs.

Cheers