### PR TITLE
Add TIMEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following list is by no means exhaustive, feel free to edit the list (will p
 | [Traces](https://github.com/datascopeanalytics/traces) | A library for unevenly-spaced time series analysis |
 | [ta-lib](https://github.com/mrjbq7/ta-lib) | Calculate technical indicators for financial time series (python wrapper around TA-Lib) |
 | [ta](https://github.com/bukosabino/ta) | Calculate technical indicators for financial time series |
-| [TIMEX](https://github.com/AlexMV12/TIMEX) | Library for creating time-series-forecasting-as-a-service platform/websites, with a fully automated data ingestion, pre-processing, and prediction pipeline (with univariate and multivariate models). Optional results visualization built on Dash.
+| [TIMEX](https://github.com/AlexMV12/TIMEX) | Library for creating time-series-forecasting-as-a-service platform/websites, with a fully automated data ingestion, pre-processing, prediction and results visualization pipeline.
 | [tsfresh](https://github.com/blue-yonder/tsfresh) | Extracts and filters features from time series, allowing supervised classificators and regressor to be applied to time series data |
 | [tslearn](https://github.com/rtavenar/tslearn) | Direct time series classifiers and regressors |
 | [tspreprocess](https://github.com/MaxBenChrist/tspreprocess) | Preprocess time series (resampling, denoising etc.), still WIP |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following list is by no means exhaustive, feel free to edit the list (will p
 | [Traces](https://github.com/datascopeanalytics/traces) | A library for unevenly-spaced time series analysis |
 | [ta-lib](https://github.com/mrjbq7/ta-lib) | Calculate technical indicators for financial time series (python wrapper around TA-Lib) |
 | [ta](https://github.com/bukosabino/ta) | Calculate technical indicators for financial time series |
+| [TIMEX](https://github.com/AlexMV12/TIMEX) | Library for creating time-series-forecasting-as-a-service platform/websites, with a fully automated data ingestion, pre-processing, and prediction pipeline (with univariate and multivariate models). Optional results visualization built on Dash.
 | [tsfresh](https://github.com/blue-yonder/tsfresh) | Extracts and filters features from time series, allowing supervised classificators and regressor to be applied to time series data |
 | [tslearn](https://github.com/rtavenar/tslearn) | Direct time series classifiers and regressors |
 | [tspreprocess](https://github.com/MaxBenChrist/tspreprocess) | Preprocess time series (resampling, denoising etc.), still WIP |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following list is by no means exhaustive, feel free to edit the list (will p
 | [Traces](https://github.com/datascopeanalytics/traces) | A library for unevenly-spaced time series analysis |
 | [ta-lib](https://github.com/mrjbq7/ta-lib) | Calculate technical indicators for financial time series (python wrapper around TA-Lib) |
 | [ta](https://github.com/bukosabino/ta) | Calculate technical indicators for financial time series |
-| [TIMEX](https://github.com/AlexMV12/TIMEX) | Library for creating time-series-forecasting-as-a-service platform/websites, with a fully automated data ingestion, pre-processing, prediction and results visualization pipeline.
+| [TIMEX](https://github.com/AlexMV12/TIMEX) | Library for creating time-series-forecasting-as-a-service platforms/websites, with a fully automated data ingestion, pre-processing, prediction and results visualization pipeline.
 | [tsfresh](https://github.com/blue-yonder/tsfresh) | Extracts and filters features from time series, allowing supervised classificators and regressor to be applied to time series data |
 | [tslearn](https://github.com/rtavenar/tslearn) | Direct time series classifiers and regressors |
 | [tspreprocess](https://github.com/MaxBenChrist/tspreprocess) | Preprocess time series (resampling, denoising etc.), still WIP |


### PR DESCRIPTION
Hello,

First of all, thank you for your time and for this project. It helped us very much in individuating works similar to the one we intended to do.

[TIMEX](https://github.com/AlexMV12/TIMEX) is a Python framework for time-series-forecasting-as-a-service.
Its main goal is to provide a way to offer users the possibility to access a fully-automated pipeline for time-series ingestion, pre-processing, and forecasting. Optionally, a visualization part, built on [Dash](https://dash.plotly.com/) is offered.

One example of the capabilities of TIMEX is this [website](https://covid-timex.it), which we made available to the public for Covid-19 forecasting in Italy.

This site could be modified to allow users to specify/upload the input data, which models to employ, using a simple JSON file, transforming it in a customizable platform for time-series-forecasting-as-a-service.

We would like to have feedback from the community, and we would be grateful if you could include TIMEX in your repository. In the future a paper on TIMEX will be made public.

Thank you very much,

Alessandro and Manuel
Politecnico di Milano